### PR TITLE
feat: Education section

### DIFF
--- a/src/components/Education/Education.module.css
+++ b/src/components/Education/Education.module.css
@@ -1,0 +1,44 @@
+.section {
+  position: relative;
+  z-index: 1;
+  padding: var(--space-20) var(--space-6);
+}
+
+.inner {
+  max-width: var(--max-width);
+  margin: 0 auto;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: var(--space-6);
+}
+
+.card {
+  padding: var(--space-8);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.institution {
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.degree {
+  font-size: 0.9375rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.years {
+  font-size: 0.8125rem;
+  color: var(--teal);
+  font-weight: 500;
+  font-family: var(--font-mono);
+  margin-top: auto;
+  padding-top: var(--space-2);
+}

--- a/src/components/Education/Education.tsx
+++ b/src/components/Education/Education.tsx
@@ -1,0 +1,26 @@
+import {education} from '../../data/portfolio';
+import {GlassCard} from '../ui/GlassCard/GlassCard';
+import {SectionHeader} from '../ui/SectionHeader/SectionHeader';
+import styles from './Education.module.css';
+
+export function Education() {
+  return (
+    <section id="education" className={styles.section} aria-labelledby="education-heading">
+      <div className={styles.inner}>
+        <SectionHeader label="Academic Background" title="Education" id="education-heading" />
+
+        <ul className={styles.grid} role="list">
+          {education.map((entry) => (
+            <li key={entry.institution}>
+              <GlassCard className={styles.card}>
+                <h3 className={styles.institution}>{entry.institution}</h3>
+                <p className={styles.degree}>{entry.degree}</p>
+                <p className={styles.years}>{entry.years}</p>
+              </GlassCard>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Education/tests/Education.test.tsx
+++ b/src/components/Education/tests/Education.test.tsx
@@ -1,0 +1,39 @@
+import {describe, it, expect} from 'vitest';
+import {render, screen} from '@testing-library/react';
+
+import {Education} from '../Education';
+import {education} from '../../../data/portfolio';
+
+describe('Education', () => {
+  it('renders the section heading', () => {
+    render(<Education />);
+    expect(screen.getByRole('heading', {level: 2})).toBeInTheDocument();
+  });
+
+  it('renders a list item for every education entry', () => {
+    render(<Education />);
+    const items = screen.getAllByRole('listitem');
+    expect(items).toHaveLength(education.length);
+  });
+
+  it("renders Queen's University", () => {
+    render(<Education />);
+    expect(screen.getByText("Queen's University")).toBeInTheDocument();
+  });
+
+  it('renders Crescent School', () => {
+    render(<Education />);
+    expect(screen.getByText('Crescent School')).toBeInTheDocument();
+  });
+
+  it('renders years for each entry', () => {
+    render(<Education />);
+    expect(screen.getByText('2012 -- 2016')).toBeInTheDocument();
+    expect(screen.getByText('2008 -- 2012')).toBeInTheDocument();
+  });
+
+  it('renders the section inside an id=education element', () => {
+    render(<Education />);
+    expect(document.getElementById('education')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

Two-column grid showing academic background. Each entry renders as a GlassCard with institution name, degree, and year range.

- 6 RTL tests: heading, list item count, both institutions, year ranges, section anchor