### PR TITLE
feat: Footer component

### DIFF
--- a/src/components/Footer/Footer.module.css
+++ b/src/components/Footer/Footer.module.css
@@ -1,0 +1,34 @@
+.footer {
+  position: relative;
+  z-index: 1;
+  padding: var(--space-8) var(--space-6);
+  border-top: 1px solid var(--card-border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+  max-width: var(--max-width);
+  margin: 0 auto;
+}
+
+.copy {
+  font-size: 0.875rem;
+  color: var(--text-tertiary);
+}
+
+.copy strong {
+  background: var(--accent-grad);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.built {
+  font-size: 0.8125rem;
+  color: var(--text-tertiary);
+}
+
+.built span {
+  color: var(--teal);
+}

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,0 +1,16 @@
+import styles from './Footer.module.css';
+
+export function Footer() {
+  const year = new Date().getFullYear();
+
+  return (
+    <footer className={styles.footer}>
+      <p className={styles.copy}>
+        &copy; {year} <strong>Alastair Lewis</strong>
+      </p>
+      <p className={styles.built}>
+        <span>Built with React and TypeScript</span>
+      </p>
+    </footer>
+  );
+}

--- a/src/components/Footer/tests/Footer.test.tsx
+++ b/src/components/Footer/tests/Footer.test.tsx
@@ -1,0 +1,27 @@
+import {describe, it, expect} from 'vitest';
+import {render, screen} from '@testing-library/react';
+
+import {Footer} from '../Footer';
+
+describe('Footer', () => {
+  it('renders the copyright name', () => {
+    render(<Footer />);
+    expect(screen.getByText(/Alastair Lewis/)).toBeInTheDocument();
+  });
+
+  it('renders the current year', () => {
+    render(<Footer />);
+    const year = String(new Date().getFullYear());
+    expect(screen.getByText(new RegExp(year))).toBeInTheDocument();
+  });
+
+  it('renders the built-with text', () => {
+    render(<Footer />);
+    expect(screen.getByText(/Built with React and TypeScript/i)).toBeInTheDocument();
+  });
+
+  it('renders a contentinfo landmark', () => {
+    render(<Footer />);
+    expect(screen.getByRole('contentinfo')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

Simple footer with dynamic copyright year and built-with attribution.

- Year is derived at render time so it stays current
- Renders as `<footer>` — the `contentinfo` landmark
- 4 RTL tests: name, year, built-with text, landmark role