### PR TITLE
chore: deploy workflow + README

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,62 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+        env:
+          VITE_BASE_PATH: /portfolio-2026/
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,2 +1,90 @@
-# portfolio-2026
-Alastair Lewis's 2026 portfolio website.
+# Alastair Lewis -- Portfolio 2026
+
+Personal portfolio site built with React 18, TypeScript, and Vite 5. Features a coral-reef glass-morphism aesthetic.
+
+## Stack
+
+| Concern | Choice |
+|---|---|
+| Bundler | Vite 5 |
+| UI | React 18 + TypeScript |
+| Styles | CSS Modules + `palette.css` design tokens |
+| Deploy | GitHub Actions to GitHub Pages |
+| Package manager | pnpm |
+| Linting | ESLint v9 flat config |
+| Formatting | Prettier 3 |
+| Testing | Vitest + React Testing Library |
+
+## Getting started
+
+```bash
+# Install dependencies
+pnpm install
+
+# Start dev server at http://localhost:5173
+pnpm dev
+
+# Type-check + build for production
+pnpm build
+
+# Preview the production build
+pnpm preview
+```
+
+## Code quality
+
+```bash
+# Lint
+pnpm lint
+
+# Auto-fix lint issues
+pnpm lint:fix
+
+# Format all src files
+pnpm format
+
+# Check formatting without writing
+pnpm format:check
+
+# Run tests
+pnpm test
+
+# Run tests with coverage
+pnpm test:coverage
+```
+
+## Project structure
+
+```
+src/
+  components/
+    ui/           # Atomic primitives (Button, GlassCard, Tag, SectionHeader, LanguageToggle)
+    BackgroundFX/ # Animated blob + bubble background
+    Nav/          # Fixed pill navigation
+    Hero/         # Landing section
+    Projects/     # Concept project cards
+    Experience/   # Vertical timeline
+    Education/    # Two-column grid
+    About/        # Bio + stack
+    Contact/      # Links
+    Footer/       # Copyright
+  styles/
+    palette.css   # All CSS custom properties + global reset
+  data/
+    types.ts      # TypeScript interfaces
+    portfolio.ts  # Static content (experience, projects, education)
+  utils/
+    classNames.ts # Class name composition utility
+  tests/
+    setup.ts      # Vitest + jest-dom setup
+```
+
+## Updating content
+
+All site content lives in `src/data/portfolio.ts`. Update the `projects`, `experience`, and `education` arrays there. TypeScript will catch any structural issues at build time.
+
+## Deploying to GitHub Pages
+
+1. In your GitHub repository settings, go to **Pages** and set the source to **GitHub Actions**.
+2. Push to `main` -- the workflow in `.github/workflows/deploy.yml` builds and deploys automatically.
+3. The site will be live at `https://alastair-lewis.github.io/portfolio-2026/`.


### PR DESCRIPTION
## What

- GitHub Actions deploy workflow: triggers on push to `main`, builds with `VITE_BASE_PATH=/portfolio-2026/`, uploads the `dist/` folder as a Pages artifact and deploys it
- README updated to reflect the actual stack and project structure

## To activate deployment

Go to **Settings → Pages** in the repo and set the source to **GitHub Actions** — the workflow handles the rest on every push to main.