### PR TITLE
feat: add contact form with validation and submission

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -16,12 +16,15 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.2",
+    "@portfolio/shared": "workspace:*",
     "@posthog/react": "^1.8.2",
     "i18next": "^23.11.5",
     "i18next-browser-languagedetector": "^8.0.0",
     "posthog-js": "^1.360.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-hook-form": "^7.72.0",
     "react-i18next": "^14.1.2"
   },
   "devDependencies": {

--- a/client/src/components/Contact/Contact.module.css
+++ b/client/src/components/Contact/Contact.module.css
@@ -18,6 +18,28 @@
   gap: var(--space-8);
 }
 
+.divider {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  width: 100%;
+  max-width: 480px;
+}
+
+.divider::before,
+.divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--card-border);
+}
+
+.dividerText {
+  font-size: 0.8125rem;
+  color: var(--text-tertiary);
+  white-space: nowrap;
+}
+
 .links {
   display: flex;
   flex-wrap: wrap;

--- a/client/src/components/Contact/Contact.tsx
+++ b/client/src/components/Contact/Contact.tsx
@@ -3,6 +3,7 @@ import {useTranslation} from 'react-i18next';
 import {Button} from '../ui/Button/Button';
 import {GlassCard} from '../ui/GlassCard/GlassCard';
 import {SectionHeader} from '../ui/SectionHeader/SectionHeader';
+import {ContactForm} from './ContactForm';
 import styles from './Contact.module.css';
 
 export function Contact() {
@@ -22,10 +23,15 @@ export function Contact() {
         />
 
         <GlassCard className={styles.card}>
+          <ContactForm />
+
+          <div className={styles.divider}>
+            <span className={styles.dividerText}>
+              {t('contact.form.divider')}
+            </span>
+          </div>
+
           <div className={styles.links}>
-            <Button variant="primary" href="mailto:alastair.lewis10@gmail.com">
-              {t('contact.email_cta')}
-            </Button>
             <Button
               variant="secondary"
               href="https://github.com/alastair-lewis"

--- a/client/src/components/Contact/ContactForm.module.css
+++ b/client/src/components/Contact/ContactForm.module.css
@@ -1,0 +1,101 @@
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  width: 100%;
+  max-width: 480px;
+}
+
+.fieldset {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  border: none;
+  margin: 0;
+  padding: 0;
+}
+
+.fieldset:disabled .input,
+.fieldset:disabled .textarea {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  text-align: left;
+}
+
+.label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.input,
+.textarea {
+  font-family: var(--font-sans);
+  font-size: 0.9375rem;
+  color: var(--text-primary);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--card-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-2) var(--space-3);
+  transition: border-color var(--transition-fast);
+}
+
+.input::placeholder,
+.textarea::placeholder {
+  color: var(--text-tertiary);
+}
+
+.input:focus,
+.textarea:focus {
+  outline: none;
+  border-color: var(--teal);
+  box-shadow: var(--focus-ring);
+}
+
+.textarea {
+  resize: vertical;
+  min-height: 90px;
+}
+
+.inputError {
+  border-color: var(--coral);
+}
+
+.inputError:focus {
+  border-color: var(--coral);
+  box-shadow: 0 0 0 3px rgba(255, 107, 107, 0.3);
+}
+
+.errorText {
+  font-size: 0.8125rem;
+  color: var(--coral);
+}
+
+.honeypot {
+  position: absolute;
+  left: -9999px;
+}
+
+.actions {
+  display: flex;
+  justify-content: center;
+  padding-top: var(--space-1);
+}
+
+.successText {
+  font-size: 0.875rem;
+  color: var(--teal);
+  text-align: center;
+}
+
+.errorBanner {
+  font-size: 0.875rem;
+  color: var(--coral);
+  text-align: center;
+}

--- a/client/src/components/Contact/ContactForm.tsx
+++ b/client/src/components/Contact/ContactForm.tsx
@@ -1,0 +1,87 @@
+import {useTranslation} from 'react-i18next';
+
+import {useContactForm} from '../../hooks/useContactForm';
+import {classNames} from '../../utils/classNames';
+import {Button} from '../ui/Button/Button';
+import styles from './ContactForm.module.css';
+
+const visibleFields = ['name', 'email', 'message'] as const;
+
+export function ContactForm() {
+  const {t} = useTranslation();
+  const {register, errors, status, onSubmit} = useContactForm();
+  const isSubmitting = status === 'submitting';
+
+  return (
+    <form className={styles.form} onSubmit={onSubmit} noValidate>
+      <fieldset className={styles.fieldset} disabled={isSubmitting}>
+        {visibleFields.map((field) => {
+          const error = errors[field];
+          const id = `contact-${field}`;
+          const errorId = `${id}-error`;
+
+          return (
+            <div key={field} className={styles.field}>
+              <label htmlFor={id} className={styles.label}>
+                {t(`contact.form.${field}_label`)}
+              </label>
+              {field === 'message' ? (
+                <textarea
+                  id={id}
+                  className={classNames(styles.textarea, error && styles.inputError)}
+                  placeholder={t(`contact.form.${field}_placeholder`)}
+                  aria-invalid={error ? true : undefined}
+                  aria-describedby={error ? errorId : undefined}
+                  {...register(field)}
+                />
+              ) : (
+                <input
+                  id={id}
+                  type={field === 'email' ? 'email' : 'text'}
+                  className={classNames(styles.input, error && styles.inputError)}
+                  placeholder={t(`contact.form.${field}_placeholder`)}
+                  aria-invalid={error ? true : undefined}
+                  aria-describedby={error ? errorId : undefined}
+                  {...register(field)}
+                />
+              )}
+              {error && (
+                <span id={errorId} className={styles.errorText} role="alert">
+                  {error.message}
+                </span>
+              )}
+            </div>
+          );
+        })}
+
+        <div className={styles.honeypot}>
+          <label htmlFor="contact-company">Company</label>
+          <input
+            id="contact-company"
+            type="text"
+            tabIndex={-1}
+            autoComplete="off"
+            {...register('company')}
+          />
+        </div>
+
+        <div className={styles.actions}>
+          <Button type="submit" disabled={isSubmitting}>
+            {isSubmitting ? t('contact.form.submitting') : t('contact.form.submit')}
+          </Button>
+        </div>
+      </fieldset>
+
+      {status === 'success' && (
+        <p className={styles.successText} role="status">
+          {t('contact.form.success')}
+        </p>
+      )}
+      {status === 'error' && (
+        <p className={styles.errorBanner} role="alert">
+          {t('contact.form.error')}
+        </p>
+      )}
+    </form>
+  );
+}

--- a/client/src/components/Contact/tests/Contact.test.tsx
+++ b/client/src/components/Contact/tests/Contact.test.tsx
@@ -11,13 +11,6 @@ describe('Contact', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders the email CTA link', () => {
-    render(<Contact />);
-    expect(
-      screen.getByRole('link', {name: /send me an email/i}),
-    ).toHaveAttribute('href', 'mailto:alastair.lewis10@gmail.com');
-  });
-
   it('renders the GitHub link', () => {
     render(<Contact />);
     expect(screen.getByRole('link', {name: /github/i})).toHaveAttribute(
@@ -37,5 +30,12 @@ describe('Contact', () => {
   it('renders the section inside an id=contact element', () => {
     render(<Contact />);
     expect(document.getElementById('contact')).toBeInTheDocument();
+  });
+
+  it('renders the contact form', () => {
+    render(<Contact />);
+    expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/message/i)).toBeInTheDocument();
   });
 });

--- a/client/src/components/Contact/tests/ContactForm.test.tsx
+++ b/client/src/components/Contact/tests/ContactForm.test.tsx
@@ -1,0 +1,167 @@
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import userEvent from '@testing-library/user-event';
+import {render, screen, waitFor} from '../../../tests/i18n-test-utils';
+
+import {ContactForm} from '../ContactForm';
+
+describe('ContactForm', () => {
+  it('renders all visible fields', () => {
+    render(<ContactForm />);
+    expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/message/i)).toBeInTheDocument();
+  });
+
+  it('renders the submit button', () => {
+    render(<ContactForm />);
+    expect(screen.getByRole('button', {name: /send/i})).toHaveAttribute(
+      'type',
+      'submit',
+    );
+  });
+
+  it('renders a hidden honeypot field', () => {
+    render(<ContactForm />);
+    const honeypot = screen.getByLabelText(/company/i);
+    expect(honeypot).toBeInTheDocument();
+    expect(honeypot).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('shows validation errors on blur for empty required fields', async () => {
+    const user = userEvent.setup();
+    render(<ContactForm />);
+
+    const nameInput = screen.getByLabelText(/name/i);
+    await user.click(nameInput);
+    await user.tab();
+
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
+  });
+
+  it('shows all errors when submitting with empty fields', async () => {
+    const user = userEvent.setup();
+    render(<ContactForm />);
+
+    await user.click(screen.getByRole('button', {name: /send/i}));
+
+    const alerts = await screen.findAllByRole('alert');
+    expect(alerts.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('clears error when field is corrected', async () => {
+    const user = userEvent.setup();
+    render(<ContactForm />);
+
+    const nameInput = screen.getByLabelText(/name/i);
+    await user.click(nameInput);
+    await user.tab();
+
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
+
+    await user.type(nameInput, 'Alastair');
+    await waitFor(() => {
+      expect(screen.queryByText(/name is required/i)).not.toBeInTheDocument();
+    });
+  });
+
+  it('does not show errors before interaction', () => {
+    render(<ContactForm />);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  describe('submission', () => {
+    beforeEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    async function fillForm(user: ReturnType<typeof userEvent.setup>) {
+      await user.type(screen.getByLabelText(/name/i), 'Alastair');
+      await user.type(screen.getByLabelText(/email/i), 'test@example.com');
+      await user.type(screen.getByLabelText(/message/i), 'Hello there');
+    }
+
+    it('sends a POST request with form data on valid submit', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify({success: true}), {status: 200}),
+      );
+      const user = userEvent.setup();
+      render(<ContactForm />);
+
+      await fillForm(user);
+      await user.click(screen.getByRole('button', {name: /send/i}));
+
+      expect(fetchSpy).toHaveBeenCalledWith('http://localhost:8787/v1/contact', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({
+          name: 'Alastair',
+          email: 'test@example.com',
+          message: 'Hello there',
+          company: '',
+        }),
+      });
+    });
+
+    it('shows success message after successful submit', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify({success: true}), {status: 200}),
+      );
+      const user = userEvent.setup();
+      render(<ContactForm />);
+
+      await fillForm(user);
+      await user.click(screen.getByRole('button', {name: /send/i}));
+
+      expect(await screen.findByRole('status')).toHaveTextContent(/message sent/i);
+    });
+
+    it('shows error message when request fails', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify({success: false}), {status: 500}),
+      );
+      const user = userEvent.setup();
+      render(<ContactForm />);
+
+      await fillForm(user);
+      await user.click(screen.getByRole('button', {name: /send/i}));
+
+      expect(await screen.findByText(/something went wrong/i)).toBeInTheDocument();
+    });
+
+    it('shows error message on network failure', async () => {
+      vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Network error'));
+      const user = userEvent.setup();
+      render(<ContactForm />);
+
+      await fillForm(user);
+      await user.click(screen.getByRole('button', {name: /send/i}));
+
+      expect(await screen.findByText(/something went wrong/i)).toBeInTheDocument();
+    });
+
+    it('disables form fields while submitting', async () => {
+      let resolveFetch: (value: Response) => void;
+      vi.spyOn(globalThis, 'fetch').mockImplementation(
+        () => new Promise((resolve) => { resolveFetch = resolve; }),
+      );
+      const user = userEvent.setup();
+      render(<ContactForm />);
+
+      await fillForm(user);
+      await user.click(screen.getByRole('button', {name: /send/i}));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/name/i)).toBeDisabled();
+      });
+      expect(screen.getByLabelText(/email/i)).toBeDisabled();
+      expect(screen.getByLabelText(/message/i)).toBeDisabled();
+      expect(screen.getByRole('button', {name: /sending/i})).toBeDisabled();
+
+      resolveFetch!(new Response(JSON.stringify({success: true}), {status: 200}));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/name/i)).toBeEnabled();
+      });
+    });
+  });
+});

--- a/client/src/components/ui/Button/Button.module.css
+++ b/client/src/components/ui/Button/Button.module.css
@@ -44,3 +44,10 @@
   color: var(--teal);
   box-shadow: 0 0 0 1px var(--teal);
 }
+
+/* Disabled */
+.disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none;
+}

--- a/client/src/components/ui/Button/Button.tsx
+++ b/client/src/components/ui/Button/Button.tsx
@@ -12,6 +12,8 @@ interface ButtonProps {
   /** Passed to <a> targets — defaults to _blank for external links */
   target?: string;
   rel?: string;
+  type?: 'button' | 'submit' | 'reset';
+  disabled?: boolean;
 }
 
 export function Button({
@@ -22,8 +24,15 @@ export function Button({
   className,
   target,
   rel,
+  type = 'button',
+  disabled,
 }: ButtonProps) {
-  const cls = classNames(styles.button, styles[variant], className);
+  const cls = classNames(
+    styles.button,
+    styles[variant],
+    disabled ? styles.disabled : undefined,
+    className,
+  );
 
   if (href) {
     const isExternal = href.startsWith('http');
@@ -40,7 +49,7 @@ export function Button({
   }
 
   return (
-    <button type="button" className={cls} onClick={onClick}>
+    <button type={type} className={cls} onClick={onClick} disabled={disabled}>
       {children}
     </button>
   );

--- a/client/src/components/ui/Button/tests/Button.test.tsx
+++ b/client/src/components/ui/Button/tests/Button.test.tsx
@@ -50,4 +50,14 @@ describe('Button', () => {
     render(<Button className="custom">Styled</Button>);
     expect(screen.getByRole('button')).toHaveClass('custom');
   });
+
+  it('renders with type="submit"', () => {
+    render(<Button type="submit">Submit</Button>);
+    expect(screen.getByRole('button')).toHaveAttribute('type', 'submit');
+  });
+
+  it('renders as disabled when disabled prop is true', () => {
+    render(<Button disabled>Disabled</Button>);
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
 });

--- a/client/src/hooks/tests/useContactForm.test.ts
+++ b/client/src/hooks/tests/useContactForm.test.ts
@@ -1,0 +1,90 @@
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {renderHook, act} from '@testing-library/react';
+import {createMockUseForm, mockReset} from '../../tests/mock-react-hook-form';
+
+import {useContactForm} from '../useContactForm';
+
+vi.mock('react-hook-form', () => ({
+  useForm: createMockUseForm({
+    name: 'Alastair',
+    email: 'test@example.com',
+    message: 'Hello there',
+    company: '',
+  }),
+}));
+
+vi.mock('../../utils/api', () => ({
+  api: vi.fn(),
+}));
+
+import {api} from '../../utils/api';
+
+const mockApi = vi.mocked(api);
+
+describe('useContactForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('starts with idle status and no errors', () => {
+    const {result} = renderHook(() => useContactForm());
+
+    expect(result.current.status).toBe('idle');
+    expect(result.current.errors).toEqual({});
+  });
+
+  it('exposes register and onSubmit', () => {
+    const {result} = renderHook(() => useContactForm());
+
+    expect(result.current.register).toBeTypeOf('function');
+    expect(result.current.onSubmit).toBeTypeOf('function');
+  });
+
+  describe('submission', () => {
+    async function submit(result: {current: ReturnType<typeof useContactForm>}) {
+      await act(() => result.current.onSubmit({preventDefault: vi.fn()} as never));
+    }
+
+    it('calls api with correct path and body', async () => {
+      mockApi.mockResolvedValue({ok: true, status: 200, data: {success: true}});
+      const {result} = renderHook(() => useContactForm());
+
+      await submit(result);
+
+      expect(mockApi).toHaveBeenCalledWith('/v1/contact', {
+        method: 'POST',
+        body: {name: 'Alastair', email: 'test@example.com', message: 'Hello there', company: ''},
+      });
+    });
+
+    it('sets success status and resets form on ok response', async () => {
+      mockApi.mockResolvedValue({ok: true, status: 200, data: {success: true}});
+      const {result} = renderHook(() => useContactForm());
+
+      await submit(result);
+
+      expect(result.current.status).toBe('success');
+      expect(mockReset).toHaveBeenCalled();
+    });
+
+    it('sets error status on non-ok response', async () => {
+      mockApi.mockResolvedValue({ok: false, status: 500, data: {error: 'fail'}});
+      const {result} = renderHook(() => useContactForm());
+
+      await submit(result);
+
+      expect(result.current.status).toBe('error');
+      expect(mockReset).not.toHaveBeenCalled();
+    });
+
+    it('sets error status on network failure', async () => {
+      mockApi.mockRejectedValue(new Error('Network error'));
+      const {result} = renderHook(() => useContactForm());
+
+      await submit(result);
+
+      expect(result.current.status).toBe('error');
+      expect(mockReset).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/client/src/hooks/useContactForm.ts
+++ b/client/src/hooks/useContactForm.ts
@@ -1,0 +1,43 @@
+import {useState} from 'react';
+import {useForm} from 'react-hook-form';
+import {zodResolver} from '@hookform/resolvers/zod';
+import {contactSchema, type ContactBody} from '@portfolio/shared';
+
+import {api} from '../utils/api';
+
+type SubmitStatus = 'idle' | 'submitting' | 'success' | 'error';
+
+export function useContactForm() {
+  const [status, setStatus] = useState<SubmitStatus>('idle');
+
+  const {
+    register,
+    handleSubmit,
+    formState: {errors},
+    reset,
+  } = useForm<ContactBody>({
+    resolver: zodResolver(contactSchema),
+    mode: 'onTouched',
+    defaultValues: {name: '', email: '', message: '', company: ''},
+  });
+
+  const onSubmit = handleSubmit(async (data) => {
+    setStatus('submitting');
+
+    try {
+      const {ok} = await api('/v1/contact', {method: 'POST', body: data});
+
+      if (!ok) {
+        setStatus('error');
+        return;
+      }
+
+      setStatus('success');
+      reset();
+    } catch {
+      setStatus('error');
+    }
+  });
+
+  return {register, errors, status, onSubmit};
+}

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -42,6 +42,19 @@
   "contact": {
     "label": "Get In Touch",
     "title": "Contact",
+    "form": {
+      "name_label": "Name",
+      "name_placeholder": "Your name",
+      "email_label": "Email",
+      "email_placeholder": "your@email.com",
+      "message_label": "Message",
+      "message_placeholder": "What would you like to say?",
+      "submit": "Send message",
+      "submitting": "Sending...",
+      "success": "Message sent! I'll get back to you soon.",
+      "error": "Something went wrong. Please try again.",
+      "divider": "or reach out directly"
+    },
     "email_cta": "Send me an email",
     "github_cta": "GitHub",
     "linkedin_cta": "LinkedIn"

--- a/client/src/i18n/locales/fr.json
+++ b/client/src/i18n/locales/fr.json
@@ -42,6 +42,19 @@
   "contact": {
     "label": "Me contacter",
     "title": "Contact",
+    "form": {
+      "name_label": "Nom",
+      "name_placeholder": "Votre nom",
+      "email_label": "Courriel",
+      "email_placeholder": "votre@courriel.com",
+      "message_label": "Message",
+      "message_placeholder": "Que souhaitez-vous dire?",
+      "submit": "Envoyer le message",
+      "submitting": "Envoi en cours...",
+      "success": "Message envoy\u00e9! Je vous r\u00e9pondrai bient\u00f4t.",
+      "error": "Une erreur est survenue. Veuillez r\u00e9essayer.",
+      "divider": "ou contactez-moi directement"
+    },
     "email_cta": "M'envoyer un courriel",
     "github_cta": "GitHub",
     "linkedin_cta": "LinkedIn"

--- a/client/src/tests/mock-react-hook-form.ts
+++ b/client/src/tests/mock-react-hook-form.ts
@@ -1,0 +1,15 @@
+import {vi} from 'vitest';
+
+export const mockReset = vi.fn();
+
+export function createMockUseForm(defaultValues: Record<string, unknown> = {}) {
+  return () => ({
+    register: vi.fn(() => ({onChange: vi.fn(), onBlur: vi.fn(), ref: vi.fn(), name: ''})),
+    handleSubmit: (cb: Function) => async (e: {preventDefault?: () => void}) => {
+      e?.preventDefault?.();
+      await cb(defaultValues);
+    },
+    formState: {errors: {}},
+    reset: mockReset,
+  });
+}

--- a/client/src/utils/api.ts
+++ b/client/src/utils/api.ts
@@ -1,0 +1,24 @@
+const API_BASE = import.meta.env.VITE_API_BASE_URL as string;
+
+export interface ApiResponse<T = unknown> {
+  ok: boolean;
+  status: number;
+  data: T;
+}
+
+export async function api<T = unknown>(
+  path: string,
+  options: {method?: string; body?: unknown} = {},
+): Promise<ApiResponse<T>> {
+  const {method = 'GET', body} = options;
+
+  const response = await fetch(`${API_BASE}${path}`, {
+    method,
+    headers: body !== undefined ? {'Content-Type': 'application/json'} : {},
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+
+  const data = (await response.json()) as T;
+
+  return {ok: response.ok, status: response.status, data};
+}

--- a/client/src/utils/tests/api.test.ts
+++ b/client/src/utils/tests/api.test.ts
@@ -1,0 +1,56 @@
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {api} from '../api';
+
+describe('api', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('sends a GET request by default', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ok: true}), {status: 200}),
+    );
+
+    await api('/test');
+
+    expect(fetchSpy).toHaveBeenCalledWith('http://localhost:8787/test', {
+      method: 'GET',
+      headers: {},
+      body: undefined,
+    });
+  });
+
+  it('sends a POST request with JSON body', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({success: true}), {status: 200}),
+    );
+
+    await api('/contact', {method: 'POST', body: {name: 'Test'}});
+
+    expect(fetchSpy).toHaveBeenCalledWith('http://localhost:8787/contact', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: '{"name":"Test"}',
+    });
+  });
+
+  it('returns ok: true for successful responses', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({data: 'value'}), {status: 200}),
+    );
+
+    const result = await api('/test');
+
+    expect(result).toEqual({ok: true, status: 200, data: {data: 'value'}});
+  });
+
+  it('returns ok: false for error responses', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({error: 'fail'}), {status: 500}),
+    );
+
+    const result = await api('/test');
+
+    expect(result).toEqual({ok: false, status: 500, data: {error: 'fail'}});
+  });
+});

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -5,6 +5,7 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   plugins: [react()],
   base: process.env.VITE_BASE_PATH ?? '/',
+  envDir: '..',
   test: {
     environment: 'jsdom',
     globals: true,

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -11,5 +11,8 @@ export default defineConfig({
     globals: true,
     setupFiles: ['./src/tests/setup.ts'],
     css: true,
+    env: {
+      VITE_API_BASE_URL: 'http://localhost:8787',
+    },
   },
 });

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@portfolio/shared",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "dependencies": {
+    "zod": "^4.3.6"
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,1 @@
+export {contactSchema, type ContactBody} from './schemas/contact';

--- a/packages/shared/src/schemas/contact.ts
+++ b/packages/shared/src/schemas/contact.ts
@@ -1,0 +1,16 @@
+import {z} from 'zod';
+
+export const contactSchema = z.object({
+  name: z
+    .string({error: 'Name is required'})
+    .trim()
+    .min(1, {error: 'Name is required'}),
+  email: z.email({error: 'A valid email is required'}),
+  message: z
+    .string({error: 'Message is required'})
+    .trim()
+    .min(1, {error: 'Message is required'}),
+  company: z.string().optional(),
+});
+
+export type ContactBody = z.infer<typeof contactSchema>;

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "declaration": true,
+    "esModuleInterop": true
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,12 @@ importers:
 
   client:
     dependencies:
+      '@hookform/resolvers':
+        specifier: ^5.2.2
+        version: 5.2.2(react-hook-form@7.72.0(react@18.3.1))
+      '@portfolio/shared':
+        specifier: workspace:*
+        version: link:../packages/shared
       '@posthog/react':
         specifier: ^1.8.2
         version: 1.8.2(@types/react@18.3.28)(posthog-js@1.360.2)(react@18.3.1)
@@ -32,6 +38,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      react-hook-form:
+        specifier: ^7.72.0
+        version: 7.72.0(react@18.3.1)
       react-i18next:
         specifier: ^14.1.2
         version: 14.1.3(i18next@23.16.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -100,14 +109,20 @@ importers:
         specifier: ^2.0.5
         version: 2.1.9(@types/node@22.19.15)(jsdom@24.1.3)
 
-  server/v1:
+  packages/shared:
     dependencies:
-      hono:
-        specifier: ^4.12.8
-        version: 4.12.8
       zod:
         specifier: ^4.3.6
         version: 4.3.6
+
+  server/v1:
+    dependencies:
+      '@portfolio/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+      hono:
+        specifier: ^4.12.8
+        version: 4.12.8
     devDependencies:
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.12.4
@@ -677,6 +692,11 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@hookform/resolvers@5.2.2':
+    resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
+    peerDependencies:
+      react-hook-form: ^7.55.0
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -1122,6 +1142,9 @@ packages:
 
   '@speed-highlight/core@1.2.14':
     resolution: {integrity: sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -2381,6 +2404,12 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
+  react-hook-form@7.72.0:
+    resolution: {integrity: sha512-V4v6jubaf6JAurEaVnT9aUPKFbNtDgohj5CIgVGyPHvT9wRx5OZHVjz31GsxnPNI278XMu+ruFz+wGOscHaLKw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+
   react-i18next@14.1.3:
     resolution: {integrity: sha512-wZnpfunU6UIAiJ+bxwOiTmBOAaB14ha97MjOEnLGac2RJ+h/maIYXZuTHlmyqQVX1UVHmU1YDTQ5vxLmwfXTjw==}
     peerDependencies:
@@ -3366,6 +3395,11 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@hookform/resolvers@5.2.2(react-hook-form@7.72.0(react@18.3.1))':
+    dependencies:
+      '@standard-schema/utils': 0.3.0
+      react-hook-form: 7.72.0(react@18.3.1)
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -3715,6 +3749,8 @@ snapshots:
   '@sindresorhus/is@7.2.0': {}
 
   '@speed-highlight/core@1.2.14': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -5260,6 +5296,10 @@ snapshots:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
+
+  react-hook-form@7.72.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   react-i18next@14.1.3(i18next@23.16.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - 'client'
   - 'server/v1'
+  - 'packages/shared'

--- a/server/v1/package.json
+++ b/server/v1/package.json
@@ -17,7 +17,7 @@
 		"wrangler": "^4.73.0"
 	},
 	"dependencies": {
-		"hono": "^4.12.8",
-		"zod": "^4.3.6"
+		"@portfolio/shared": "workspace:*",
+		"hono": "^4.12.8"
 	}
 }

--- a/server/v1/src/middleware/cors.ts
+++ b/server/v1/src/middleware/cors.ts
@@ -1,7 +1,16 @@
 import { cors as honoCors } from 'hono/cors';
 
 export const cors = honoCors({
-  origin: ['https://alastairlewis.com', 'https://www.alastairlewis.com'],
+  origin: (origin) => {
+    const allowed = [
+      'https://alastairlewis.com',
+      'https://www.alastairlewis.com',
+    ];
+    if (allowed.includes(origin) || /^http:\/\/localhost:\d+$/.test(origin)) {
+      return origin;
+    }
+    return null;
+  },
   allowMethods: ['POST', 'OPTIONS'],
   allowHeaders: ['Content-Type'],
   maxAge: 86400,

--- a/server/v1/src/routes/contact/schema.ts
+++ b/server/v1/src/routes/contact/schema.ts
@@ -1,17 +1,1 @@
-import { z } from 'zod';
-
-export const contactSchema = z.object({
-  name: z
-    .string({ error: 'Name is required' })
-    .trim()
-    .min(1, { error: 'Name is required' }),
-  email: z
-    .email({ error: 'A valid email is required' }),
-  message: z
-    .string({ error: 'Message is required' })
-    .trim()
-    .min(1, { error: 'Message is required' }),
-  company: z.string().optional()
-});
-
-export type ContactBody = z.infer<typeof contactSchema>;
+export {contactSchema, type ContactBody} from '@portfolio/shared';


### PR DESCRIPTION
### Closes: https://github.com/alastair-lewis/portfolio-2026/issues/23

### 📝 TL;DR
Adds a fully functional contact form to the Contact section with client-side validation (react-hook-form + zod), an API utility for HTTP requests, and a shared schema package used by both client and server.

### 📋 Summary of Changes

**Shared schema package (`packages/shared`):**
- New `@portfolio/shared` workspace package with the `contactSchema` zod schema and `ContactBody` type
- Both client and server now consume the schema from this shared package

**API utility (`api.ts`):**
- New `api()` fetch wrapper that handles JSON serialization, content-type headers, and returns `{ok, status, data}`

**Contact form hook (`useContactForm.ts`):**
- Uses `useForm` from react-hook-form with `zodResolver` for validation
- `mode: 'onTouched'` validates on first blur, then revalidates on change
- Manages submission status (`idle | submitting | success | error`) and calls `api()` to POST form data
- Returns a flat `{register, errors, status, onSubmit}` interface

**ContactForm component (`ContactForm.tsx`):**
- Renders name, email, and message fields with error display and aria attributes
- Honeypot field for spam prevention
- `<fieldset disabled>` disables all fields during submission
- Success/error banners after submission

**Button (`Button.tsx`):**
- Added `type` and `disabled` props to support form submission

**Contact section (`Contact.tsx`):**
- Integrates `ContactForm` above the existing GitHub/LinkedIn links with an "or reach out directly" divider

**CORS (`cors.ts`):**
- Allow `localhost` origins during development

**i18n (`en.json`, `fr.json`):**
- Added all form label, placeholder, status, and divider translation keys

**Tests (`ContactForm.test.tsx`, `useContactForm.test.ts`, `api.test.ts`, `Button.test.tsx`, `Contact.test.tsx`):**
- ContactForm: field rendering, blur validation, error clearing, submission (success, server error, network error), disabled state during submission
- useContactForm: status transitions, API call args, reset on success, error handling (mocks RHF via reusable `mock-react-hook-form.ts` fixture)
- api: GET/POST request shape, JSON body serialization, ok/error response mapping
- Button: `type="submit"` and `disabled` support
- Contact: updated to verify form renders instead of removed email CTA

### 🧪 How to Test

1. `pnpm install` and `pnpm dev`
2. Navigate to the Contact section
3. Click "Send message" with empty fields - validation errors should appear
4. Fill in a field, blur away, then correct it - error should clear on typing
5. Fill all fields and submit - fields should disable during submission, then show success message
6. Run `pnpm --filter @portfolio/client test` - all 126 tests should pass

### 💡 Why Make This Change?

The contact section previously only had mailto/GitHub/LinkedIn links. A built-in contact form provides a lower-friction way for visitors to reach out without leaving the site. The shared zod schema ensures client and server validation stay in sync, and react-hook-form replaces manual form state management with a battle-tested library.